### PR TITLE
[BUGFIX] Remove dependencies on FLASC temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "flasc",
+    # "flasc",
     # "matplotlib~=3.0",
     # "pandas~=2.0",
     # "dash>=2.0.0",

--- a/tests/controller_library_test.py
+++ b/tests/controller_library_test.py
@@ -72,50 +72,50 @@ def test_controller_instantiation():
     _ = WindFarmPowerTrackingController(interface=test_interface, input_dict=test_hercules_dict)
 
 
-def test_LookupBasedWakeSteeringController():
-    test_interface = HerculesADInterface(test_hercules_dict)
+# def test_LookupBasedWakeSteeringController():
+#     test_interface = HerculesADInterface(test_hercules_dict)
     
-    # No lookup table passed; simply passes through wind direction to yaw angles
-    test_controller = LookupBasedWakeSteeringController(
-        interface=test_interface,
-        input_dict=test_hercules_dict
-    )
+#     # No lookup table passed; simply passes through wind direction to yaw angles
+#     test_controller = LookupBasedWakeSteeringController(
+#         interface=test_interface,
+#         input_dict=test_hercules_dict
+#     )
 
-    # Check that the controller can be stepped
-    test_hercules_dict["time"] = 20
-    test_hercules_dict_out = test_controller.step(hercules_dict=test_hercules_dict)
-    test_angles = np.array(
-        test_hercules_dict_out["hercules_comms"]["amr_wind"]["test_farm"]["turbine_yaw_angles"]
-    )
-    wind_directions = np.array(
-        test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_wind_directions"]
-    )
-    assert np.allclose(test_angles, wind_directions)
+#     # Check that the controller can be stepped
+#     test_hercules_dict["time"] = 20
+#     test_hercules_dict_out = test_controller.step(hercules_dict=test_hercules_dict)
+#     test_angles = np.array(
+#         test_hercules_dict_out["hercules_comms"]["amr_wind"]["test_farm"]["turbine_yaw_angles"]
+#     )
+#     wind_directions = np.array(
+#         test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_wind_directions"]
+#     )
+#     assert np.allclose(test_angles, wind_directions)
 
-    # Lookup table that specified 20 degree offset for T000, 10 degree offset for T001 for all wind
-    # directions
-    test_offsets = np.array([20.0, 10.0])
-    df_opt_test = pd.DataFrame(data={
-        "wind_direction":[220.0, 320.0, 220.0, 320.0],
-        "wind_speed":[0.0, 0.0, 20.0, 20.0],
-        "yaw_angles_opt":[test_offsets]*4, 
-        "turbulence_intensity":[0.06]*4
-    })
-    test_controller = LookupBasedWakeSteeringController(
-        interface=test_interface,
-        input_dict=test_hercules_dict,
-        df_yaw=df_opt_test
-    )
+#     # Lookup table that specified 20 degree offset for T000, 10 degree offset for T001 for all wind
+#     # directions
+#     test_offsets = np.array([20.0, 10.0])
+#     df_opt_test = pd.DataFrame(data={
+#         "wind_direction":[220.0, 320.0, 220.0, 320.0],
+#         "wind_speed":[0.0, 0.0, 20.0, 20.0],
+#         "yaw_angles_opt":[test_offsets]*4, 
+#         "turbulence_intensity":[0.06]*4
+#     })
+#     test_controller = LookupBasedWakeSteeringController(
+#         interface=test_interface,
+#         input_dict=test_hercules_dict,
+#         df_yaw=df_opt_test
+#     )
 
-    test_hercules_dict["time"] = 20
-    test_hercules_dict_out = test_controller.step(hercules_dict=test_hercules_dict)
-    test_angles = np.array(
-        test_hercules_dict_out["hercules_comms"]["amr_wind"]["test_farm"]["turbine_yaw_angles"]
-    )
-    wind_directions = np.array(
-        test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_wind_directions"]
-    )
-    assert np.allclose(test_angles, wind_directions - test_offsets)
+#     test_hercules_dict["time"] = 20
+#     test_hercules_dict_out = test_controller.step(hercules_dict=test_hercules_dict)
+#     test_angles = np.array(
+#         test_hercules_dict_out["hercules_comms"]["amr_wind"]["test_farm"]["turbine_yaw_angles"]
+#     )
+#     wind_directions = np.array(
+#         test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_wind_directions"]
+#     )
+#     assert np.allclose(test_angles, wind_directions - test_offsets)
 
 def test_WindBatteryController():
 

--- a/tests/controller_library_test.py
+++ b/tests/controller_library_test.py
@@ -12,7 +12,8 @@
 
 # See https://nrel.github.io/wind-hybrid-open-controller for documentation
 import numpy as np
-import pandas as pd
+
+# import pandas as pd
 from whoc.controllers import (
     LookupBasedWakeSteeringController,
     WindBatteryController,
@@ -92,8 +93,8 @@ def test_controller_instantiation():
 #     )
 #     assert np.allclose(test_angles, wind_directions)
 
-#     # Lookup table that specified 20 degree offset for T000, 10 degree offset for T001 for all wind
-#     # directions
+#     # Lookup table that specified 20 degree offset for T000, 10 degree offset for T001 for all
+#     # wind directions
 #     test_offsets = np.array([20.0, 10.0])
 #     df_opt_test = pd.DataFrame(data={
 #         "wind_direction":[220.0, 320.0, 220.0, 320.0],

--- a/whoc/controllers/lookup_based_wake_steering_controller.py
+++ b/whoc/controllers/lookup_based_wake_steering_controller.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 
-from flasc.wake_steering.lookup_table_tools import get_yaw_angles_interpolant
+#from flasc.wake_steering.lookup_table_tools import get_yaw_angles_interpolant
 from whoc.controllers.controller_base import ControllerBase
 
 
@@ -32,7 +32,12 @@ class LookupBasedWakeSteeringController(ControllerBase):
                 print("No offsets received; assuming nominal aligned control.")
             self.wake_steering_interpolant = None
         else:
-            self.wake_steering_interpolant = get_yaw_angles_interpolant(df_yaw)
+            # Temporarily raise an error, until we have FLASC updated and compatible
+            raise NotImplementedError(
+                "The wake steering controller is not currently implemented due to a dependency ",
+                " conflict from FLASC."
+            )
+            # self.wake_steering_interpolant = get_yaw_angles_interpolant(df_yaw)
 
         # Set initial conditions
         yaw_IC = input_dict["controller"]["initial_conditions"]["yaw"]


### PR DESCRIPTION
[FLASC](https://github.com/NREL/flasc/) is not yet compatible with [FLORIS v4](https://github.com/NREL/floris/tree/v4). Because the `LookupBasedWakeSteeringController` depends on FLASC, a dependency issue arises when trying to use WHOC with Hercules' develop branch.

As a temporary fix, this PR removes all FLASC dependencies, disabling the `LookupBasedWakeSteeringController` in the process.

I will create an issue to look for a more permanent solution.