### PR TITLE
Up numpy requirement to numpy~=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 ]
 dependencies = [
     "numpy~=2.0",
-    "flasc~=2.0",
+    "flasc~=2.3",
     "pandas~=2.0",
     "matplotlib~=3.0",
-    "floris~=4.0",
+    "floris~=4.3",
     "zmq",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "numpy~=1.20",
+    "numpy~=2.0",
     "flasc~=2.0",
     "pandas~=2.0",
     "matplotlib~=3.0",


### PR DESCRIPTION
Following [FLORIS](https://github.com/NREL/floris/pull/1051), which is a dependency of WHOC, this PR ups the `numpy` dependency to numpy version 2. 

It may also be necessary to also update the FLORIS requirement to `floris~=4.3`. I will test that once the FLORIS PR is merged and FLORIS v4.3 (containing FLORIS's `numpy~=2.0` requirement) is released. Until that time, this PR should remain a draft and should not be merged.

I have checked locally that tests and examples run, so I don't expect any issues with moving up to numpy v2 once the FLORIS update is merged.

I have opened a sister [PR on Hercules](https://github.com/NREL/hercules/pull/138).