### PR TITLE
Remove unneeded information from example input files

### DIFF
--- a/examples/lookup-based_wake_steering_florisstandin/inputs/hercules_input.yaml
+++ b/examples/lookup-based_wake_steering_florisstandin/inputs/hercules_input.yaml
@@ -1,11 +1,9 @@
-# Input YAML for emy_python
-
 # Name
-name: example_000
+name: lookup-based_wake_steering_florisstandin
 
 ###
 # Describe this emulator setup
-description: Just a solar plant
+description: Two-turbine wind farm
 
 dt: 0.5
 
@@ -16,7 +14,6 @@ hercules_comms:
     wind_farm_0:
       type: amr_wind_local #options are amr_wind or amr_wind_local
       amr_wind_input_file: inputs/amr_input.inp
-      yaw_simulator_name: yaw_system_0 # can also use "none" (without quotes)
 
   helics:
 
@@ -40,20 +37,7 @@ hercules_comms:
 
 py_sims:
 
-  solar_farm_0: # The name of py_sim object 1
-
-    py_sim_type: SimpleSolar
-    capacity: 50 # MW
-    efficiency: 0.5 #Fraction
-
-    initial_conditions:
-
-      power: 25 # MW
-      irradiance: 1000
-
 controller:
-
-  controller_type: SimpleYawController # This may not be needed
   num_turbines: 2 # Should match AMR-Wind! Ideally, would come from AMR-wind
   initial_conditions:
       yaw: 270. # degrees (same for all turbines) (will this work?)

--- a/examples/simple_hybrid_plant/inputs/hercules_input.yaml
+++ b/examples/simple_hybrid_plant/inputs/hercules_input.yaml
@@ -45,7 +45,7 @@ py_sims:
     lon: -105.1778
     elev: 1829
     target_system_capacity: 100000 # kW
-    target_dc_ac_ratio: 1.2 # Does not affect output power
+    target_dc_ac_ratio: 1.3
 
     initial_conditions:
       power: 25 # MW

--- a/examples/simple_hybrid_plant/inputs/hercules_input.yaml
+++ b/examples/simple_hybrid_plant/inputs/hercules_input.yaml
@@ -1,7 +1,5 @@
-# Input YAML for emy_python
-
 # Name
-name: example_000
+name: simple_hybrid_plant
 
 ###
 # Describe this emulator setup
@@ -46,11 +44,10 @@ py_sims:
     lat: 39.7442
     lon: -105.1778
     elev: 1829
-
-    # capacity: 100 # MW
+    target_system_capacity: 100000 # kW
+    target_dc_ac_ratio: 1.2 # Does not affect output power
 
     initial_conditions:
-
       power: 25 # MW
       dni: 1000
 

--- a/examples/wind_farm_power_tracking_florisstandin/inputs/hercules_input.yaml
+++ b/examples/wind_farm_power_tracking_florisstandin/inputs/hercules_input.yaml
@@ -1,25 +1,19 @@
-# Input YAML for emy_python
-
-# Name
-name: example_000
+name: wind_farm_power_tracking_florisstandin
 
 ###
 # Describe this emulator setup
-description: Just a solar plant
+description: Two-turbine wind farm
 
 dt: 0.5
 
 hercules_comms:
 
   amr_wind:
-
     wind_farm_0:
       type: amr_wind_local #options are amr_wind or amr_wind_local
       amr_wind_input_file: inputs/amr_input.inp
-      yaw_simulator_name: yaw_system_0 # can also use "none" (without quotes)
 
   helics:
-
     config:
         name: hercules # What is the purpose of this name
         use_dash_frontend: False
@@ -35,25 +29,11 @@ hercules_comms:
         endpoint_interval: 1
         starttime: 0
         stoptime: 100
-        
         Agent: ControlCenter
 
 py_sims:
 
-  solar_farm_0: # The name of py_sim object 1
-
-    py_sim_type: SimpleSolar
-    capacity: 50 # MW
-    efficiency: 0.5 #Fraction
-
-    initial_conditions:
-
-      power: 25 # MW
-      irradiance: 1000
-
 controller:
-
-  controller_type: SimpleYawController # This may not be needed
   num_turbines: 2 # Should match AMR-Wind! Ideally, would come from AMR-wind
   initial_conditions:
       yaw: 270. # degrees (same for all turbines) (will this work?)


### PR DESCRIPTION
This PR removes unnecessary fields from the example input files across the WHOC examples/

- ~battery_control_comparison~
- [x] lookup-based_wake_steering_florisstandin
- [x] simple_hybrid_plant
- [x] wind_farm_power_tracking_florisstandin