### PR TITLE
Provide more flexibility for having various control loops

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -4,9 +4,13 @@ The `whoc.controllers` module contains a library of wind and hybrid power plant
 controllers. Each controller must inherit from `ControllerBase` (see 
 controller_base.py) and implement a
 mandatory `compute_controls()` method, which contains the relevant control 
-algorithm and writes final control signals to the `controls_dict` attribute 
-as key-value pairs. `compute_controls()` is, in turn, called in the `step()`
-method of `ControllerBase`.
+algorithm. `compute_controls()` must accept a single argument dictionary 
+(nominally called `measurement_dict`) that contains the necessary input
+signals and return a second dictionary (nominally called `controls_dict`) that
+returns the control actions. In the basic set up, `measurement_dict` is 
+provided to `compute_controls()` by the `step()` method defined on
+`ControllerBase`, and the returned `controls_dict` is then passed via the
+interface at the conclusion of the `step()` method.
 
 ## Available controllers
 

--- a/tests/controller_library_test.py
+++ b/tests/controller_library_test.py
@@ -236,7 +236,9 @@ def test_HybridSupervisoryControllerBaseline():
     test_controller.prev_wind_power = sum(wind_current) # To override filtering
 
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     # Expected outputs
     wind_solar_current = sum(wind_current)+solar_current
@@ -282,7 +284,9 @@ def test_HybridSupervisoryControllerBaseline_subsets():
     test_controller.prev_wind_power = sum(wind_current) # To override filtering
 
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     wind_solar_current = sum(wind_current)+solar_current
     wind_power_cmd = sum(wind_current)-(wind_solar_current - power_ref)/2
@@ -306,7 +310,9 @@ def test_HybridSupervisoryControllerBaseline_subsets():
     test_controller.prev_solar_power = 0
     test_controller.prev_wind_power = sum(wind_current) # To override filtering
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     wind_power_cmd = 20000 + power_ref
     solar_power_cmd = 0 # No solar controller!
@@ -329,7 +335,9 @@ def test_HybridSupervisoryControllerBaseline_subsets():
     test_controller.prev_solar_power = solar_current # To override filtering
     test_controller.prev_wind_power = 0
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     wind_power_cmd = 0 # No wind controller!
     solar_power_cmd = 20000 + power_ref
@@ -362,7 +370,9 @@ def test_HybridSupervisoryControllerBaseline_subsets():
     test_controller.prev_solar_power = 0
     test_controller.prev_wind_power = sum(wind_current) # To override filtering
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     wind_power_cmd = power_ref
     solar_power_cmd = 0 # No solar controller!
@@ -385,7 +395,9 @@ def test_HybridSupervisoryControllerBaseline_subsets():
     test_controller.prev_solar_power = solar_current # To override filtering
     test_controller.prev_wind_power = 0
     test_controller.step(test_hercules_dict) # Run the controller once to update measurements
-    supervisory_control_output = test_controller.supervisory_control()
+    supervisory_control_output = test_controller.supervisory_control(
+        test_controller._measurements_dict
+    )
 
     wind_power_cmd = 0 # No wind controller!
     solar_power_cmd = power_ref
@@ -423,19 +435,19 @@ def test_BatteryController():
     test_hercules_dict["py_sims"]["test_battery"]["outputs"] = {"power": 0, "soc": 0.3}
     test_hercules_dict["external_signals"]["plant_power_reference"] = power_ref
     test_controller.step(test_hercules_dict)
-    out_0 = test_controller.controls_dict["power_setpoint"]
+    out_0 = test_controller._controls_dict["power_setpoint"]
     assert 0 < out_0 < power_ref
 
     # Test that increasing the gain increases the control response
     test_controller = BatteryController(test_interface, test_hercules_dict, {"k_batt":0.5})
     test_controller.step(test_hercules_dict)
-    out_1 = test_controller.controls_dict["power_setpoint"]
+    out_1 = test_controller._controls_dict["power_setpoint"]
     assert out_0 < out_1 < power_ref
 
     # Decreasing the gain slows the response
     test_controller = BatteryController(test_interface, test_hercules_dict, {"k_batt":0.01})
     test_controller.step(test_hercules_dict)
-    out_2 = test_controller.controls_dict["power_setpoint"]
+    out_2 = test_controller._controls_dict["power_setpoint"]
     assert 0 < out_2 < out_0
 
     # More complex test for smoothing capabilities (mid-low gain)
@@ -469,7 +481,7 @@ def test_BatteryController():
         {"clipping_thresholds":clipping_threshold_0}
     )
     test_controller_0.step(test_hercules_dict)
-    out_0 = test_controller_0.controls_dict["power_setpoint"]
+    out_0 = test_controller_0._controls_dict["power_setpoint"]
 
     test_controller_1 = BatteryController(
         test_interface,
@@ -477,7 +489,7 @@ def test_BatteryController():
         {"clipping_thresholds":clipping_threshold_1}
     )
     test_controller_1.step(test_hercules_dict)
-    out_1 = test_controller_1.controls_dict["power_setpoint"]
+    out_1 = test_controller_1._controls_dict["power_setpoint"]
 
     test_controller_2 = BatteryController(
         test_interface,
@@ -485,7 +497,7 @@ def test_BatteryController():
         {"clipping_thresholds":clipping_threshold_2}
     )
     test_controller_2.step(test_hercules_dict)
-    out_2 = test_controller_2.controls_dict["power_setpoint"]
+    out_2 = test_controller_2._controls_dict["power_setpoint"]
 
     assert out_0 == out_1
     assert out_0 == out_0
@@ -496,11 +508,11 @@ def test_BatteryController():
     test_controller_2.x = 0
     test_hercules_dict["external_signals"]["plant_power_reference"] = 20000
     test_controller_0.step(test_hercules_dict)
-    out_0 = test_controller_0.controls_dict["power_setpoint"]
+    out_0 = test_controller_0._controls_dict["power_setpoint"]
     test_controller_1.step(test_hercules_dict)
-    out_1 = test_controller_1.controls_dict["power_setpoint"]
+    out_1 = test_controller_1._controls_dict["power_setpoint"]
     test_controller_2.step(test_hercules_dict)
-    out_2 = test_controller_2.controls_dict["power_setpoint"]
+    out_2 = test_controller_2._controls_dict["power_setpoint"]
 
     assert out_0 == out_1
     assert out_0 > out_2
@@ -510,8 +522,8 @@ def test_BatteryController():
     test_controller_0.x = 0
     test_controller_1.x = 0
     test_controller_0.step(test_hercules_dict)
-    out_0 = test_controller_0.controls_dict["power_setpoint"]
+    out_0 = test_controller_0._controls_dict["power_setpoint"]
     test_controller_1.step(test_hercules_dict)
-    out_1 = test_controller_1.controls_dict["power_setpoint"]
+    out_1 = test_controller_1._controls_dict["power_setpoint"]
     
     assert out_0 > out_1

--- a/tests/controller_library_test.py
+++ b/tests/controller_library_test.py
@@ -422,7 +422,7 @@ def test_SolarPassthroughController():
     test_controller = SolarPassthroughController(test_interface, test_hercules_dict)
 
     power_ref = 1000
-    measurements_dict = {"solar_power_reference": power_ref}
+    measurements_dict = {"power_reference": power_ref}
     controls_dict = test_controller.compute_controls(measurements_dict)
     assert controls_dict["power_setpoint"] == power_ref
 

--- a/tests/controller_library_test.py
+++ b/tests/controller_library_test.py
@@ -401,18 +401,18 @@ def test_BatteryPassthroughController():
     test_controller = BatteryPassthroughController(test_interface, test_hercules_dict)
 
     power_ref = 1000
-    test_controller.measurements_dict["power_reference"] = power_ref
-    test_controller.compute_controls()
-    assert test_controller.controls_dict["power_setpoint"] == power_ref
+    measurements_dict = {"power_reference": power_ref}
+    controls_dict = test_controller.compute_controls(measurements_dict)
+    assert controls_dict["power_setpoint"] == power_ref
 
 def test_SolarPassthroughController():
     test_interface = HerculesHybridADInterface(test_hercules_dict)
     test_controller = SolarPassthroughController(test_interface, test_hercules_dict)
 
     power_ref = 1000
-    test_controller.measurements_dict["solar_power_reference"] = power_ref
-    test_controller.compute_controls()
-    assert test_controller.controls_dict["power_setpoint"] == power_ref
+    measurements_dict = {"solar_power_reference": power_ref}
+    controls_dict = test_controller.compute_controls(measurements_dict)
+    assert controls_dict["power_setpoint"] == power_ref
 
 def test_BatteryController():
     test_interface = HerculesBatteryInterface(test_hercules_dict)

--- a/tests/interface_library_test.py
+++ b/tests/interface_library_test.py
@@ -120,7 +120,7 @@ def test_HerculesHybridADInterface():
         == test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["wind_speed"]
     )
     assert (
-        measurements["plant_power_reference"]
+        measurements["power_reference"]
         == test_hercules_dict["external_signals"]["wind_power_reference"]
     )
     assert (

--- a/tests/interface_library_test.py
+++ b/tests/interface_library_test.py
@@ -57,7 +57,7 @@ def test_HerculesADInterface():
         == test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_wind_directions"]
     )
     assert (
-        measurements["turbine_powers"]
+        measurements["wind_turbine_powers"]
         == test_hercules_dict["hercules_comms"]["amr_wind"]["test_farm"]["turbine_powers"]
     )
     test_forecast = {
@@ -69,7 +69,7 @@ def test_HerculesADInterface():
     controls_dict = {"yaw_angles": [270.0, 278.9]}
     controls_dict2 = {
         "yaw_angles": [270.0, 268.9],
-        "power_setpoints": [3000.0, 3000.0],
+        "wind_power_setpoints": [3000.0, 3000.0],
     }
     interface.check_controls(controls_dict)
     interface.check_controls(controls_dict2)
@@ -77,7 +77,7 @@ def test_HerculesADInterface():
     bad_controls_dict1 = {"yaw_angels": [270.0, 268.9]}  # Misspelling
     bad_controls_dict2 = {
         "yaw_angles": [270.0, 268.9],
-        "power_setpoints": [3000.0, 3000.0],
+        "wind_power_setpoints": [3000.0, 3000.0],
         "unavailable_control": [0.0, 0.0],
     }
     bad_controls_dict3 = {"yaw_angles": [270.0, 268.9, 270.0]}  # Mismatched number of turbines

--- a/whoc/controllers/battery_controller.py
+++ b/whoc/controllers/battery_controller.py
@@ -109,13 +109,13 @@ class BatteryController(ControllerBase):
 
         return np.clip(reference_power, -r_discharge, r_charge)
 
-    def compute_controls(self):
+    def compute_controls(self, measurements_dict):
         """
         Main compute_controls method for BatteryController.
         """
-        reference_power = self.measurements_dict["power_reference"]
-        current_power = self.measurements_dict["battery_power"]
-        soc = self.measurements_dict["battery_soc"]
+        reference_power = measurements_dict["power_reference"]
+        current_power = measurements_dict["battery_power"]
+        soc = measurements_dict["battery_soc"]
 
         # Apply reference clipping
         reference_power = self.soc_clipping(soc, reference_power)
@@ -128,7 +128,9 @@ class BatteryController(ControllerBase):
         # Update controller internal state
         self.x = self.a * self.x + self.b * e
 
-        self.controls_dict["power_setpoint"] = current_power + u
+        controls_dict = {"power_setpoint": current_power + u}
+
+        return controls_dict
 
 class BatteryPassthroughController(ControllerBase):
     """
@@ -140,9 +142,8 @@ class BatteryPassthroughController(ControllerBase):
         """
         super().__init__(interface, verbose)
 
-    def compute_controls(self):
+    def compute_controls(self, measurements_dict):
         """"
         Main compute_controls method for BatteryPassthroughController.
         """
-        reference_power = self.measurements_dict["power_reference"]
-        self.controls_dict["power_setpoint"] = reference_power
+        return {"power_setpoint": measurements_dict["power_reference"]}

--- a/whoc/controllers/controller_base.py
+++ b/whoc/controllers/controller_base.py
@@ -7,18 +7,18 @@ class ControllerBase(metaclass=ABCMeta):
         self.verbose = verbose
 
         # Initialize measurements and controls to send
-        self.measurements_dict = {}
-        self.controls_dict = {}
+        self._measurements_dict = {}
+        self._controls_dict = {}
 
     def _receive_measurements(self, input_dict=None):
         # May need to eventually loop here, depending on server set up.
-        self.measurements_dict = self._s.get_measurements(input_dict)
+        self._measurements_dict = self._s.get_measurements(input_dict)
 
         return None
 
     def _send_controls(self, input_dict=None):
-        self._s.check_controls(self.controls_dict)
-        output_dict = self._s.send_controls(input_dict, **self.controls_dict)
+        self._s.check_controls(self._controls_dict)
+        output_dict = self._s.send_controls(input_dict, **self._controls_dict)
 
         return output_dict
 
@@ -27,11 +27,12 @@ class ControllerBase(metaclass=ABCMeta):
         # throughout this method.
         self._receive_measurements(input_dict)
 
-        self.controls_dict = self.compute_controls(self.measurements_dict)
+        self._controls_dict = self.compute_controls(self._measurements_dict)
 
         output_dict = self._send_controls(input_dict)
 
         return output_dict
+
     @abstractmethod
     def compute_controls(self, measurements_dict: dict) -> dict:
         pass  # Control algorithms should be implemented in the compute_controls 

--- a/whoc/controllers/controller_base.py
+++ b/whoc/controllers/controller_base.py
@@ -26,15 +26,13 @@ class ControllerBase(metaclass=ABCMeta):
         # If not running with direct hercules integration, hercules_dict may simply be None
         # throughout this method.
         self._receive_measurements(input_dict)
-        
-        self.compute_controls()
-        
+
+        self.controls_dict = self.compute_controls(self.measurements_dict)
+
         output_dict = self._send_controls(input_dict)
-        
+
         return output_dict
-    
-    
     @abstractmethod
-    def compute_controls(self):
+    def compute_controls(self, measurements_dict: dict) -> dict:
         pass  # Control algorithms should be implemented in the compute_controls 
         # method of the child class. 

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -52,7 +52,9 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
 
     def compute_controls(self, measurements_dict):
         # Run supervisory control logic
-        wind_reference, solar_reference, battery_reference = self.supervisory_control()
+        wind_reference, solar_reference, battery_reference = self.supervisory_control(
+            measurements_dict
+        )
 
         # Package the controls for the individual controllers, step, and return
         controls_dict = {}
@@ -70,10 +72,10 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
             controls_dict["solar_power_setpoint"] = solar_controls_dict["power_setpoint"]
         if self._has_battery_controller:
             battery_measurements_dict = {
-                "time": self.measurements_dict["time"],
+                "time": measurements_dict["time"],
                 "power_reference": battery_reference,
-                "battery_power": self.measurements_dict["battery_power"],
-                "battery_soc": self.measurements_dict["battery_soc"]
+                "battery_power": measurements_dict["battery_power"],
+                "battery_soc": measurements_dict["battery_soc"]
             }
             battery_controls_dict = self.battery_controller.compute_controls(
                 battery_measurements_dict
@@ -82,33 +84,33 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
 
         return controls_dict
 
-    def supervisory_control(self):
+    def supervisory_control(self, measurements_dict):
         # Extract measurements sent
-        time = self.measurements_dict["time"] # noqa: F841 
+        time = measurements_dict["time"] # noqa: F841 
         if self._has_wind_controller:
-            wind_power = np.array(self.measurements_dict["wind_turbine_powers"]).sum()
-            wind_speed = self.measurements_dict["wind_speed"] # noqa: F841
+            wind_power = np.array(measurements_dict["wind_turbine_powers"]).sum()
+            wind_speed = measurements_dict["wind_speed"] # noqa: F841
         else:
             wind_power = 0
             wind_speed = 0 # noqa: F841
 
         if self._has_solar_controller:
-            solar_power = self.measurements_dict["solar_power"]
-            solar_dni = self.measurements_dict["solar_dni"] # direct normal irradiance # noqa: F841
-            solar_aoi = self.measurements_dict["solar_aoi"] # angle of incidence # noqa: F841
+            solar_power = measurements_dict["solar_power"]
+            solar_dni = measurements_dict["solar_dni"] # direct normal irradiance # noqa: F841
+            solar_aoi = measurements_dict["solar_aoi"] # angle of incidence # noqa: F841
         else:
             solar_power = 0
             solar_dni = 0 # noqa: F841
             solar_aoi = 0 # noqa: F841
 
         if self._has_battery_controller:
-            battery_power = self.measurements_dict["battery_power"]
-            battery_soc = self.measurements_dict["battery_soc"]
+            battery_power = measurements_dict["battery_power"]
+            battery_soc = measurements_dict["battery_soc"]
         else:
             battery_power = 0
             battery_soc = 0
 
-        plant_power_reference = self.measurements_dict["plant_power_reference"]
+        plant_power_reference = measurements_dict["plant_power_reference"]
 
         # Filter the wind and solar power measurements to reduce noise and improve closed-loop
         # controller damping

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -61,13 +61,13 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
         if self._has_wind_controller:
             print("UPPER measurements:", measurements_dict)
             wind_measurements_dict = {
-                "wind_power_reference": wind_reference,
+                "power_reference": wind_reference,
                 "wind_turbine_powers": measurements_dict["wind_turbine_powers"]
             }
             wind_controls_dict = self.wind_controller.compute_controls(wind_measurements_dict)
             controls_dict["wind_power_setpoints"] = wind_controls_dict["wind_power_setpoints"]
         if self._has_solar_controller:
-            solar_measurements_dict = {"solar_power_reference": solar_reference}
+            solar_measurements_dict = {"power_reference": solar_reference}
             solar_controls_dict = self.solar_controller.compute_controls(solar_measurements_dict)
             controls_dict["solar_power_setpoint"] = solar_controls_dict["power_setpoint"]
         if self._has_battery_controller:
@@ -110,7 +110,7 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
             battery_power = 0
             battery_soc = 0
 
-        plant_power_reference = measurements_dict["plant_power_reference"]
+        plant_power_reference = measurements_dict["power_reference"]
 
         # Filter the wind and solar power measurements to reduce noise and improve closed-loop
         # controller damping

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -62,10 +62,10 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
             print("UPPER measurements:", measurements_dict)
             wind_measurements_dict = {
                 "wind_power_reference": wind_reference,
-                "turbine_powers": measurements_dict["wind_turbine_powers"]
+                "wind_turbine_powers": measurements_dict["wind_turbine_powers"]
             }
             wind_controls_dict = self.wind_controller.compute_controls(wind_measurements_dict)
-            controls_dict["wind_power_setpoints"] = wind_controls_dict["power_setpoints"]
+            controls_dict["wind_power_setpoints"] = wind_controls_dict["wind_power_setpoints"]
         if self._has_solar_controller:
             solar_measurements_dict = {"solar_power_reference": solar_reference}
             solar_controls_dict = self.solar_controller.compute_controls(solar_measurements_dict)

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -59,7 +59,6 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
         # Package the controls for the individual controllers, step, and return
         controls_dict = {}
         if self._has_wind_controller:
-            print("UPPER measurements:", measurements_dict)
             wind_measurements_dict = {
                 "power_reference": wind_reference,
                 "wind_turbine_powers": measurements_dict["wind_turbine_powers"]

--- a/whoc/controllers/lookup_based_wake_steering_controller.py
+++ b/whoc/controllers/lookup_based_wake_steering_controller.py
@@ -37,13 +37,12 @@ class LookupBasedWakeSteeringController(ControllerBase):
         self.wd_store = [270.]*self.n_turbines # TODO: update this?
 
 
-    def compute_controls(self):
-        self.wake_steering_angles()
+    def compute_controls(self, measurements_dict):
+        return self.wake_steering_angles(measurements_dict["wind_directions"])
 
-    def wake_steering_angles(self):
-        
+    def wake_steering_angles(self, wind_directions):
+
         # Handle possible bad data
-        wind_directions = self.measurements_dict["wind_directions"]
         wind_speeds = [8.0]*self.n_turbines # TODO: enable extraction of wind speed in Hercules
         if not wind_directions: # Received empty or None
             if self.verbose:
@@ -64,6 +63,4 @@ class LookupBasedWakeSteeringController(ControllerBase):
             yaw_offsets = np.diag(interpolated_angles)
             yaw_setpoint = (np.array(wind_directions) - yaw_offsets).tolist()
 
-        self.controls_dict = {"yaw_angles": yaw_setpoint}
-
-        return None
+        return {"yaw_angles": yaw_setpoint}

--- a/whoc/controllers/solar_passthrough_controller.py
+++ b/whoc/controllers/solar_passthrough_controller.py
@@ -9,4 +9,4 @@ class SolarPassthroughController(ControllerBase):
         super().__init__(interface, verbose)
 
     def compute_controls(self, measurements_dict):
-        return {"power_setpoint": measurements_dict["solar_power_reference"]}
+        return {"power_setpoint": measurements_dict["power_reference"]}

--- a/whoc/controllers/solar_passthrough_controller.py
+++ b/whoc/controllers/solar_passthrough_controller.py
@@ -8,6 +8,5 @@ class SolarPassthroughController(ControllerBase):
     def __init__(self, interface, input_dict, verbose=True):
         super().__init__(interface, verbose)
 
-    def compute_controls(self):
-        reference_power = self.measurements_dict["solar_power_reference"]
-        self.controls_dict["power_setpoint"] = reference_power
+    def compute_controls(self, measurements_dict):
+        return {"power_setpoint": measurements_dict["solar_power_reference"]}

--- a/whoc/controllers/wind_farm_power_tracking_controller.py
+++ b/whoc/controllers/wind_farm_power_tracking_controller.py
@@ -23,13 +23,13 @@ class WindFarmPowerDistributingController(ControllerBase):
         # For startup
 
 
-    def compute_controls(self):
-        if "wind_power_reference" in self.measurements_dict:
-            farm_power_reference = self.measurements_dict["wind_power_reference"]
+    def compute_controls(self, measurements_dict):
+        if "wind_power_reference" in measurements_dict:
+            farm_power_reference = measurements_dict["wind_power_reference"]
         else:
             farm_power_reference = POWER_SETPOINT_DEFAULT
         
-        self.turbine_power_references(farm_power_reference=farm_power_reference)
+        return self.turbine_power_references(farm_power_reference=farm_power_reference)
 
     def turbine_power_references(self, farm_power_reference=POWER_SETPOINT_DEFAULT):
         """
@@ -43,12 +43,12 @@ class WindFarmPowerDistributingController(ControllerBase):
 
         # Split farm power reference among turbines and set "no value" for yaw angles (Floris not
         # compatible with both power_setpoints and yaw_angles).
-        self.controls_dict = {
+        controls_dict = {
             "power_setpoints": [farm_power_reference/self.n_turbines]*self.n_turbines,
             "yaw_angles": [-1000]*self.n_turbines
         }
 
-        return None
+        return controls_dict
 
 class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
     """
@@ -116,7 +116,7 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         
         # set "no value" for yaw angles (Floris not compatible with both 
         # power_setpoints and yaw_angles)
-        self.controls_dict = {
+        controls_dict = {
             "power_setpoints": list(turbine_power_setpoints),
             "yaw_angles": [-1000]*self.n_turbines
         }
@@ -126,4 +126,4 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         # self.u_prev = u
         # self.u_i_prev = u_i
 
-        return None
+        return controls_dict

--- a/whoc/controllers/wind_farm_power_tracking_controller.py
+++ b/whoc/controllers/wind_farm_power_tracking_controller.py
@@ -18,7 +18,7 @@ class WindFarmPowerDistributingController(ControllerBase):
         self.turbines = range(self.n_turbines)
 
         # Set initial conditions
-        self.controls_dict = {"power_setpoints": [POWER_SETPOINT_DEFAULT] * self.n_turbines}
+        #self.controls_dict = {"power_setpoints": [POWER_SETPOINT_DEFAULT] * self.n_turbines}
 
         # For startup
 
@@ -31,7 +31,7 @@ class WindFarmPowerDistributingController(ControllerBase):
         
         return self.turbine_power_references(
             farm_power_reference=farm_power_reference,
-            turbine_powers=measurements_dict["turbine_powers"]
+            turbine_powers=measurements_dict["wind_turbine_powers"]
         )
 
     def turbine_power_references(
@@ -51,7 +51,7 @@ class WindFarmPowerDistributingController(ControllerBase):
         # Split farm power reference among turbines and set "no value" for yaw angles (Floris not
         # compatible with both power_setpoints and yaw_angles).
         controls_dict = {
-            "power_setpoints": [farm_power_reference/self.n_turbines]*self.n_turbines,
+            "wind_power_setpoints": [farm_power_reference/self.n_turbines]*self.n_turbines,
             "yaw_angles": [-1000]*self.n_turbines
         }
 
@@ -127,7 +127,7 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         # set "no value" for yaw angles (Floris not compatible with both 
         # power_setpoints and yaw_angles)
         controls_dict = {
-            "power_setpoints": list(turbine_power_setpoints),
+            "wind_power_setpoints": list(turbine_power_setpoints),
             "yaw_angles": [-1000]*self.n_turbines
         }
 

--- a/whoc/controllers/wind_farm_power_tracking_controller.py
+++ b/whoc/controllers/wind_farm_power_tracking_controller.py
@@ -29,9 +29,16 @@ class WindFarmPowerDistributingController(ControllerBase):
         else:
             farm_power_reference = POWER_SETPOINT_DEFAULT
         
-        return self.turbine_power_references(farm_power_reference=farm_power_reference)
+        return self.turbine_power_references(
+            farm_power_reference=farm_power_reference,
+            turbine_powers=measurements_dict["turbine_powers"]
+        )
 
-    def turbine_power_references(self, farm_power_reference=POWER_SETPOINT_DEFAULT):
+    def turbine_power_references(
+            self,
+            farm_power_reference=POWER_SETPOINT_DEFAULT,
+            turbine_powers=None
+        ):
         """
         Compute turbine-level power setpoints based on farm-level power
         reference signal.
@@ -76,7 +83,11 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         # self.ai_prev = [0.33]*self.n_turbines # TODO: different method for anti-windup?
         # self.n_saturated = 0 
 
-    def turbine_power_references(self, farm_power_reference=POWER_SETPOINT_DEFAULT):
+    def turbine_power_references(
+            self,
+            farm_power_reference=POWER_SETPOINT_DEFAULT,
+            turbine_powers=None
+        ):
         """
         Compute turbine-level power setpoints based on farm-level power
         reference signal.
@@ -86,8 +97,7 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         - None (sets self.controls_dict)
         """
         
-        turbine_current_powers = self.measurements_dict["turbine_powers"]
-        farm_current_power = np.sum(turbine_current_powers)
+        farm_current_power = np.sum(turbine_powers)
         farm_current_error = farm_power_reference - farm_current_power
 
         self.n_saturated = 0 # TODO: determine whether to use gain scheduling
@@ -112,7 +122,7 @@ class WindFarmPowerTrackingController(WindFarmPowerDistributingController):
         u = u_p #+ u_i
         delta_P_ref = u
 
-        turbine_power_setpoints = np.array(turbine_current_powers) + delta_P_ref
+        turbine_power_setpoints = np.array(turbine_powers) + delta_P_ref
         
         # set "no value" for yaw angles (Floris not compatible with both 
         # power_setpoints and yaw_angles)

--- a/whoc/controllers/wind_farm_power_tracking_controller.py
+++ b/whoc/controllers/wind_farm_power_tracking_controller.py
@@ -24,8 +24,8 @@ class WindFarmPowerDistributingController(ControllerBase):
 
 
     def compute_controls(self, measurements_dict):
-        if "wind_power_reference" in measurements_dict:
-            farm_power_reference = measurements_dict["wind_power_reference"]
+        if "power_reference" in measurements_dict:
+            farm_power_reference = measurements_dict["power_reference"]
         else:
             farm_power_reference = POWER_SETPOINT_DEFAULT
         

--- a/whoc/interfaces/hercules_actuator_disk_interface.py
+++ b/whoc/interfaces/hercules_actuator_disk_interface.py
@@ -44,7 +44,7 @@ class HerculesADInterface(InterfaceBase):
             "wind_directions": wind_directions,
             # "wind_speeds":wind_speeds,
             "wind_turbine_powers": turbine_powers,
-            "wind_power_reference": wind_power_reference,
+            "power_reference": wind_power_reference,
             "forecast": forecast,
         }
 

--- a/whoc/interfaces/hercules_actuator_disk_interface.py
+++ b/whoc/interfaces/hercules_actuator_disk_interface.py
@@ -43,7 +43,7 @@ class HerculesADInterface(InterfaceBase):
             "time": time,
             "wind_directions": wind_directions,
             # "wind_speeds":wind_speeds,
-            "turbine_powers": turbine_powers,
+            "wind_turbine_powers": turbine_powers,
             "wind_power_reference": wind_power_reference,
             "forecast": forecast,
         }
@@ -51,7 +51,7 @@ class HerculesADInterface(InterfaceBase):
         return measurements
 
     def check_controls(self, controls_dict):
-        available_controls = ["yaw_angles", "power_setpoints"]
+        available_controls = ["yaw_angles", "wind_power_setpoints"]
 
         for k in controls_dict.keys():
             if k not in available_controls:
@@ -61,15 +61,15 @@ class HerculesADInterface(InterfaceBase):
                     "Length of setpoint " + k + " does not match the number of turbines."
                 )
 
-    def send_controls(self, hercules_dict, yaw_angles=None, power_setpoints=None):
+    def send_controls(self, hercules_dict, yaw_angles=None, wind_power_setpoints=None):
         if yaw_angles is None:
             yaw_angles = [-1000] * self.n_turbines
-        if power_setpoints is None:
-            power_setpoints = [POWER_SETPOINT_DEFAULT] * self.n_turbines
+        if wind_power_setpoints is None:
+            wind_power_setpoints = [POWER_SETPOINT_DEFAULT] * self.n_turbines
 
         hercules_dict["hercules_comms"]["amr_wind"][self.wf_name]["turbine_yaw_angles"] = yaw_angles
         hercules_dict["hercules_comms"]["amr_wind"][self.wf_name][
             "turbine_power_setpoints"
-        ] = power_setpoints
+        ] = wind_power_setpoints
 
         return hercules_dict

--- a/whoc/interfaces/hercules_hybrid_actuator_disk_interface.py
+++ b/whoc/interfaces/hercules_hybrid_actuator_disk_interface.py
@@ -49,7 +49,7 @@ class HerculesHybridADInterface(InterfaceBase):
 
         measurements = {
             "time": time,
-            "plant_power_reference": plant_power_reference,
+            "power_reference": plant_power_reference,
             "forecast": forecast,
         } 
 


### PR DESCRIPTION
This PR makes a change to how the `controller.compute_controls()` method that is required on every controller operates. Rather than operating on an assumed existing attribute `self.measurement_dict` and resulting in a save attribute `self.controls_dict` (returning `None`), `compute_controls()` now explicitly receives a single keyword argument `measurement_dict` and returns `controls_dict`. 

The reason for doing this is that supervisory controllers often have component level controllers as attributes (see, for example, the `HybridSupervisoryControllerBaseline`. Previously there was some awkward handling where the lower level controllers' `measurement_dict` and `controls_dict` attributes where modified/accessed by the supervisory controller; now, the supervisory controller can simply create its own `measurement_dict` and receive back the `controls_dict` from the lower-level controller explicitly, which should make having multiple levels of control (hierarchical control) more straightforward.

In doing so, this PR addresses #56 