### PR TITLE
Update README with WETO note and SWR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WHOC controllers will also call on design tools such as
 
 ## WETO software
 
-FLORIS is primarily developed with the support from the U.S. Department of Energy and
+WHOC is primarily developed with the support from the U.S. Department of Energy and
 is part of the [WETO Software Stack](https://nrel.github.io/WETOStack).
 For more information and other integrated modeling software, see:
 


### PR DESCRIPTION
This PR updates the WHOC README to include:
- A note regarding WETO software, similar to those added to other repositories (e.g. [FLORIS](https://github.com/NREL/floris/pull/1112)).
- Adding software record number (SWR) for NREL record-keeping.

This follows a minor update to the LISCENCE file that I pushed as a direct commit to main (and then merged back into develop).