### PR TITLE
Add support for batteries to v2 hybrid controller

### DIFF
--- a/tests/hercules_v2_interfaces_test.py
+++ b/tests/hercules_v2_interfaces_test.py
@@ -27,11 +27,12 @@ test_hercules_dict = {
         "aoi": 30.0,
     },
     "battery": {
-        "size": 10.0,
-        "energy_capacity": 40.0,
-        "power": 10.0,
+        "size": 10.0e3,
+        "energy_capacity": 40.0e3,
+        "power": 10.0e3,
         "soc": 0.3,
-        "charge_rate":20
+        "charge_rate": 20e3,
+        "discharge_rate": 15e3,
     },
     "electrolyzer": {
         "H2_mfr": 0.03,
@@ -116,10 +117,10 @@ def test_HerculesHybridLongRunInterface():
         test_hercules_dict["solar_farm"]["capacity"]
     )
     assert interface.plant_parameters["battery_power_capacity"] == (
-        test_hercules_dict["battery"]["size"] * 1e3
+        test_hercules_dict["battery"]["size"]
     )
     assert interface.plant_parameters["battery_energy_capacity"] == (
-        test_hercules_dict["battery"]["energy_capacity"] * 1e3
+        test_hercules_dict["battery"]["energy_capacity"]
     )
     assert interface.plant_parameters["n_turbines"] == (
         test_hercules_dict["wind_farm"]["n_turbines"]
@@ -135,7 +136,7 @@ def test_HerculesHybridLongRunInterface():
         measurements["wind_turbine_powers"] == test_hercules_dict["wind_farm"]["turbine_powers"]
     )
     assert measurements["solar_power"] == test_hercules_dict["solar_farm"]["power"]
-    assert measurements["battery_power"] == test_hercules_dict["battery"]["power"] * -1e3
+    assert measurements["battery_power"] == test_hercules_dict["battery"]["power"]
     assert measurements["battery_soc"] == test_hercules_dict["battery"]["soc"]
 
     # Test check_controls()
@@ -171,7 +172,7 @@ def test_HerculesHybridLongRunInterface():
     )
     assert (
         controls_dict["battery_power_setpoint"]
-        == -test_hercules_dict_out["battery"]["power_setpoint"] * 1e3
+        == test_hercules_dict_out["battery"]["power_setpoint"]
     )
 
     # Check that controller and plant parameters are set correctly

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -294,7 +294,7 @@ class HybridSupervisoryControllerMultiRef(HybridSupervisoryControllerBaseline):
                     battery_reference,
                     self.plant_parameters["interconnect_limit"] - unconstrained_power,
                 )
-                if battery_power > 0:  # Make sure not to double count battery power when charging
+                if battery_power < 0:  # Make sure not to double count battery power when charging
                     unconstrained_power += battery_power
             else:
                 raise ValueError(f"Invalid generation type {component} in curtailment_order.")

--- a/whoc/controllers/hybrid_supervisory_controller.py
+++ b/whoc/controllers/hybrid_supervisory_controller.py
@@ -37,7 +37,7 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
         self.wind_reference = 0
         self.solar_reference = 0
         self.battery_reference = 0
-
+        self.prev_battery_power = 0
         self.prev_wind_power = 0
         self.prev_solar_power = 0
 
@@ -172,6 +172,7 @@ class HybridSupervisoryControllerBaseline(ControllerBase):
 
         self.prev_solar_power = solar_power
         self.prev_wind_power = wind_power
+        self.prev_battery_power = battery_power
         self.wind_reference = wind_reference
         self.solar_reference = solar_reference
         self.battery_reference = battery_reference

--- a/whoc/interfaces/hercules_v2_interface.py
+++ b/whoc/interfaces/hercules_v2_interface.py
@@ -119,13 +119,13 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
 
         # Battery parameters
         if self._has_battery_component:
-            self.plant_parameters["battery_power_capacity"] = h_dict["battery"]["size"] * 1e3
+            self.plant_parameters["battery_power_capacity"] = h_dict["battery"]["size"] 
             self.plant_parameters["battery_energy_capacity"] = (
-                h_dict["battery"]["energy_capacity"] * 1e3
+                h_dict["battery"]["energy_capacity"] 
             )
-            self.plant_parameters["battery_charge_rate"] = h_dict["battery"]["charge_rate"] * 1e3
+            self.plant_parameters["battery_charge_rate"] = h_dict["battery"]["charge_rate"]
             self.plant_parameters["battery_discharge_rate"] = (
-                h_dict["battery"]["discharge_rate"] * 1e3
+                h_dict["battery"]["discharge_rate"] 
             )
 
         # Electrolyzer parameters
@@ -203,7 +203,7 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             measurements["solar_aoi"] = h_dict["solar_farm"]["aoi"]
             total_power += measurements["solar_power"]
         if self._has_battery_component:
-            measurements["battery_power"] = -h_dict["battery"]["power"] * 1e3
+            measurements["battery_power"] = -h_dict["battery"]["power"] 
             measurements["battery_soc"] = h_dict["battery"]["soc"]
             total_power += measurements["battery_power"]
         if self._has_hydrogen_component:
@@ -242,6 +242,6 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
 
         if self._has_battery_component:
             # Set battery power setpoint (negative for discharge)
-            h_dict["battery"]["power_setpoint"] = -battery_power_setpoint / 1e3
+            h_dict["battery"]["power_setpoint"] = -battery_power_setpoint
 
         return h_dict

--- a/whoc/interfaces/hercules_v2_interface.py
+++ b/whoc/interfaces/hercules_v2_interface.py
@@ -24,15 +24,14 @@ class HerculesInterfaceBase(InterfaceBase):
         else:
             self.plant_parameters = {}
 
+
 class HerculesWindLongRunInterface(HerculesInterfaceBase):
     def __init__(self, h_dict):
         super().__init__(h_dict)
 
         # Wind farm parameters
         if "wind_farm" not in h_dict:
-            raise ValueError(
-                "h_dict must contain 'wind_farm' key to use this interface."
-            )
+            raise ValueError("h_dict must contain 'wind_farm' key to use this interface.")
         self.plant_parameters["nameplate_capacity"] = h_dict["wind_farm"]["capacity"]
         self.plant_parameters["n_turbines"] = h_dict["wind_farm"]["n_turbines"]
         self.plant_parameters["turbines"] = range(self.plant_parameters["n_turbines"])
@@ -124,8 +123,9 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             self.plant_parameters["battery_energy_capacity"] = (
                 h_dict["battery"]["energy_capacity"] * 1e3
             )
-            self.plant_parameters["battery_charge_rate"] = (
-                h_dict["battery"]["charge_rate"] * 1e3
+            self.plant_parameters["battery_charge_rate"] = h_dict["battery"]["charge_rate"] * 1e3
+            self.plant_parameters["battery_discharge_rate"] = (
+                h_dict["battery"]["discharge_rate"] * 1e3
             )
 
         # Electrolyzer parameters
@@ -136,7 +136,7 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
         available_controls = [
             "wind_power_setpoints",
             "solar_power_setpoint",
-            "battery_power_setpoint"
+            "battery_power_setpoint",
         ]
 
         for k in controls_dict.keys():
@@ -168,12 +168,19 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             measurements["plant_power_reference"] = plant_power_reference
 
             if "wind_power_reference" in h_dict["external_signals"]:
-                measurements["wind_power_reference"] = \
-                    h_dict["external_signals"]["wind_power_reference"]
+                measurements["wind_power_reference"] = h_dict["external_signals"][
+                    "wind_power_reference"
+                ]
 
             if "solar_power_reference" in h_dict["external_signals"]:
-                measurements["solar_power_reference"] = \
-                    h_dict["external_signals"]["solar_power_reference"]
+                measurements["solar_power_reference"] = h_dict["external_signals"][
+                    "solar_power_reference"
+                ]
+
+            if "battery_power_reference" in h_dict["external_signals"]:
+                measurements["battery_power_reference"] = h_dict["external_signals"][
+                    "battery_power_reference"
+                ]
 
             for k in h_dict["external_signals"].keys():
                 if "forecast" in k != "wind_power_reference":

--- a/whoc/interfaces/hercules_v2_interface.py
+++ b/whoc/interfaces/hercules_v2_interface.py
@@ -203,7 +203,7 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             measurements["solar_aoi"] = h_dict["solar_farm"]["aoi"]
             total_power += measurements["solar_power"]
         if self._has_battery_component:
-            measurements["battery_power"] = -h_dict["battery"]["power"] 
+            measurements["battery_power"] = h_dict["battery"]["power"] 
             measurements["battery_soc"] = h_dict["battery"]["soc"]
             total_power += measurements["battery_power"]
         if self._has_hydrogen_component:
@@ -241,7 +241,7 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             h_dict["solar_farm"]["power_setpoint"] = solar_power_setpoint
 
         if self._has_battery_component:
-            # Set battery power setpoint (negative for discharge)
-            h_dict["battery"]["power_setpoint"] = -battery_power_setpoint
+            # Set battery power setpoint (positive for discharge)
+            h_dict["battery"]["power_setpoint"] = battery_power_setpoint
 
         return h_dict

--- a/whoc/interfaces/hercules_v2_interface.py
+++ b/whoc/interfaces/hercules_v2_interface.py
@@ -203,7 +203,7 @@ class HerculesHybridLongRunInterface(HerculesInterfaceBase):
             measurements["solar_aoi"] = h_dict["solar_farm"]["aoi"]
             total_power += measurements["solar_power"]
         if self._has_battery_component:
-            measurements["battery_power"] = h_dict["battery"]["power"] 
+            measurements["battery_power"] = h_dict["battery"]["power"]
             measurements["battery_soc"] = h_dict["battery"]["soc"]
             total_power += measurements["battery_power"]
         if self._has_hydrogen_component:


### PR DESCRIPTION
This PR adds support to include batteries in the v2 hybrid controller, following the simple pattern of solar where in general the external reference is followed unless it would violate the interconnect limit.  The curtailment_order is generalized a little to allow for more than 2 components lists.