### PR TITLE
add battery price soc controller and tests

### DIFF
--- a/tests/battery_test.py
+++ b/tests/battery_test.py
@@ -1,0 +1,124 @@
+from whoc.controllers.battery_controller import (
+    BatteryPriceSOCController,
+)
+from whoc.interfaces import HerculesHybridLongRunInterface
+
+test_hercules_dict = {
+    "dt": 1,
+    "time": 0,
+    "plant": {"interconnect_limit": 10},
+    "battery": {
+        "size": 100.0,
+        "energy_capacity": 400.0,
+        "power": 100.0,
+        "soc": 0.5,
+        "charge_rate": 50.0,
+        "discharge_rate": 100.0,
+    },
+    "external_signals": {  # Is this OK like this?
+        "charge_price": 0.0,
+        "discharge_price": 25.0,
+        "lmp_rt": 10.0,
+    },
+}
+
+
+def test_BatteryPriceSOCController_init():
+    test_interface = HerculesHybridLongRunInterface(test_hercules_dict)
+
+    # Initialize controller
+    test_controller = BatteryPriceSOCController(test_interface, test_hercules_dict)
+
+    # Check that the controller is initialized correctly
+    assert (
+        test_controller.rated_power_charging == test_hercules_dict["battery"]["charge_rate"] * 1e3
+    )
+    assert (
+        test_controller.rated_power_discharging
+        == test_hercules_dict["battery"]["discharge_rate"] * 1e3
+    )
+
+
+def test_BatteryPriceSOCController_compute_controls():
+    test_interface = HerculesHybridLongRunInterface(test_hercules_dict)
+
+    # Initialize controller
+    test_controller = BatteryPriceSOCController(test_interface, test_hercules_dict)
+
+    # For testing, overwrite the high_soc_price, high_soc, low_soc_price, and low_soc
+    test_controller.high_soc_price = 25.0
+    test_controller.high_soc = 0.8
+    test_controller.low_soc_price = 0.0
+    test_controller.low_soc = 0.2
+
+    # Test the high soc condition when lmp_rt is above discharge price
+    # but below the high_soc_price
+    measurement_dict = {
+        "battery_soc": 0.9,
+        "lmp_rt": 24,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == 0.0
+
+    # Test when lmp_rt is above high_soc_price
+    measurement_dict = {
+        "battery_soc": 0.9,
+        "lmp_rt": 26,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == test_controller.rated_power_discharging
+
+    # Test when lmp_rt is above the charge price and below the high_soc
+    measurement_dict = {
+        "battery_soc": 0.7,
+        "lmp_rt": 22,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == test_controller.rated_power_discharging
+
+    # Test when lmp_rt is in between the charge and discharge price
+    measurement_dict = {
+        "battery_soc": 0.5,
+        "lmp_rt": 15,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == 0.0
+
+    # Test when soc is above the low_soc, and lmp_rt is below the charge price
+    measurement_dict = {
+        "battery_soc": 0.25,
+        "lmp_rt": 5,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == -1 * test_controller.rated_power_charging
+
+    # Test when soc is below the low_soc, and lmp_rt is below the charge price but above the low_soc_price
+    measurement_dict = {
+        "battery_soc": 0.1,
+        "lmp_rt": 15,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == 0
+
+    # Test when soc is below the low_soc, and lmp_rt is below the low_soc_price
+    measurement_dict = {
+        "battery_soc": 0.1,
+        "lmp_rt": -5,
+        "discharge_price": 20,
+        "charge_price": 10,
+    }
+    controls_dict = test_controller.compute_controls(measurement_dict)
+    assert controls_dict["power_setpoint"] == -1 * test_controller.rated_power_charging

--- a/whoc/controllers/battery_controller.py
+++ b/whoc/controllers/battery_controller.py
@@ -147,3 +147,46 @@ class BatteryPassthroughController(ControllerBase):
         Main compute_controls method for BatteryPassthroughController.
         """
         return {"power_setpoint": measurements_dict["power_reference"]}
+
+
+class BatteryPriceSOCController(ControllerBase):
+    """
+    Controller considers price and SOC to determine power setpoint.
+    """
+    def __init__(self, interface, input_dict, verbose=True):
+        super().__init__(interface, verbose)
+
+        # For now hard code certain set points
+        self.high_soc_price = 25 # $/MWh
+        self.high_soc = 0.8 # Above this SOC, only discharge if price is higher than high_soc_price
+        self.low_soc_price = 0 # $/MWh
+        self.low_soc = 0.2 # Below this SOC, only charge if price is lower than low_soc_price
+
+        self.rated_power_charging = input_dict["battery"]["charge_rate"] * 1e3
+        self.rated_power_discharging = input_dict["battery"]["discharge_rate"] * 1e3
+
+    def compute_controls(self, measurements_dict):
+
+        soc = measurements_dict["battery_soc"]
+        charge_price = measurements_dict["charge_price"]
+        discharge_price = measurements_dict["discharge_price"]
+        lmp_rt = measurements_dict["lmp_rt"]
+
+        
+        power_reference = 0
+
+        # Note that the convention is followed where charging is negative power
+        # This matches what is in place in the hercules/hybrid_plant level and 
+        # will be inverted before passing into the battery modules
+        if (soc <= self.high_soc) and (lmp_rt > discharge_price):
+            power_reference = self.rated_power_discharging
+        elif (soc > self.high_soc) and (lmp_rt > self.high_soc_price):
+            power_reference = self.rated_power_discharging
+        elif (soc >= self.low_soc) and (lmp_rt < charge_price):
+            power_reference = -1 * self.rated_power_charging
+        elif (soc < self.low_soc) and (lmp_rt < self.low_soc_price):
+            power_reference = -1 * self.rated_power_charging
+
+
+
+        return {"power_setpoint":power_reference}


### PR DESCRIPTION
Add a new battery controller that is passed in a charge_price and discharge_price, as well as the lmp real time price.  The battery power is set based on these, with an added condition that if SOC is above/below a certain threshold, the price must be above/below a higher level to justify charging/discharging.

The PR includes tests of the new controller