### PR TITLE
Feature/preallocate_measurements

### DIFF
--- a/hycon/interfaces/hercules_interface.py
+++ b/hycon/interfaces/hercules_interface.py
@@ -129,42 +129,45 @@ class HerculesInterface(InterfaceBase):
 
         # Handle external signals (parse and pass to individual components)
         if "external_signals" in h_dict:
-            external_signals = h_dict["external_signals"]
 
-            if "plant_power_reference" in external_signals:
-                measurements["plant_power_reference"] = external_signals["plant_power_reference"]
+            if "plant_power_reference" in h_dict["external_signals"]:
+                measurements["plant_power_reference"] = (
+                    h_dict["external_signals"]["plant_power_reference"]
+                )
 
-            if "wind_power_reference" in external_signals and self._has_wind_component:
-                measurements["wind_farm"]["power_reference"] = external_signals[
-                    "wind_power_reference"
-                ]
+            if "wind_power_reference" in h_dict["external_signals"] and self._has_wind_component:
+                measurements["wind_farm"]["power_reference"] = (
+                    h_dict["external_signals"]["wind_power_reference"]
+                )
 
-            if "solar_power_reference" in external_signals and self._has_solar_component:
-                measurements["solar_farm"]["power_reference"] = external_signals[
-                    "solar_power_reference"
-                ]
+            if "solar_power_reference" in h_dict["external_signals"] and self._has_solar_component:
+                measurements["solar_farm"]["power_reference"] = (
+                    h_dict["external_signals"]["solar_power_reference"]
+                )
 
             if self._has_battery_component:
-                if "battery_power_reference" in external_signals:
-                    measurements["battery"]["power_reference"] = external_signals[
-                        "battery_power_reference"
-                    ]
+                if "battery_power_reference" in h_dict["external_signals"]:
+                    measurements["battery"]["power_reference"] = (
+                        h_dict["external_signals"]["battery_power_reference"]
+                    )
 
-            if "hydrogen_reference" in external_signals and self._has_hydrogen_component:
-                measurements["hydrogen"]["power_reference"] = external_signals["hydrogen_reference"]
+            if "hydrogen_reference" in h_dict["external_signals"] and self._has_hydrogen_component:
+                measurements["hydrogen"]["power_reference"] = (
+                    h_dict["external_signals"]["hydrogen_reference"]
+                )
 
             # Grid price information (using pre-computed keys for performance)
-            if "lmp_da_00" in external_signals:
-                measurements["DA_LMP_24hours"] = [external_signals[k] for k in self._lmp_da_keys]
-            if "lmp_da" in external_signals:
-                measurements["DA_LMP"] = external_signals["lmp_da"]
-            if "lmp_rt" in external_signals:
-                measurements["RT_LMP"] = external_signals["lmp_rt"]
+            if "lmp_da_00" in h_dict["external_signals"]:
+                measurements["DA_LMP_24hours"] = [h_dict["external_signals"][k] for k in self._lmp_da_keys]
+            if "lmp_da" in h_dict["external_signals"]:
+                measurements["DA_LMP"] = h_dict["external_signals"]["lmp_da"]
+            if "lmp_rt" in h_dict["external_signals"]:
+                measurements["RT_LMP"] = h_dict["external_signals"]["lmp_rt"]
 
             # Special handling for forecast elements
-            for k, v in external_signals.items():
+            for k in h_dict["external_signals"].keys():
                 if "forecast" in k:
-                    measurements["forecast"][k] = v
+                    measurements["forecast"][k] = h_dict["external_signals"][k]
 
         measurements["total_power"] = total_power
 

--- a/hycon/interfaces/hercules_interface.py
+++ b/hycon/interfaces/hercules_interface.py
@@ -158,7 +158,9 @@ class HerculesInterface(InterfaceBase):
 
             # Grid price information (using pre-computed keys for performance)
             if "lmp_da_00" in h_dict["external_signals"]:
-                measurements["DA_LMP_24hours"] = [h_dict["external_signals"][k] for k in self._lmp_da_keys]
+                measurements["DA_LMP_24hours"] = [
+                    h_dict["external_signals"][k] for k in self._lmp_da_keys
+                ]
             if "lmp_da" in h_dict["external_signals"]:
                 measurements["DA_LMP"] = h_dict["external_signals"]["lmp_da"]
             if "lmp_rt" in h_dict["external_signals"]:

--- a/hycon/interfaces/hercules_interface.py
+++ b/hycon/interfaces/hercules_interface.py
@@ -64,6 +64,9 @@ class HerculesInterface(InterfaceBase):
         if self._has_hydrogen_component:
             self.plant_parameters["hydrogen"] = {}
 
+        # Pre-compute LMP keys to avoid string formatting in get_measurements
+        self._lmp_da_keys = tuple(f"lmp_da_{h:02d}" for h in range(24))
+
     def check_controls(self, controls_dict):
         available_controls = [
             "wind_power_setpoints",
@@ -126,47 +129,42 @@ class HerculesInterface(InterfaceBase):
 
         # Handle external signals (parse and pass to individual components)
         if "external_signals" in h_dict:
+            external_signals = h_dict["external_signals"]
 
-            if "plant_power_reference" in h_dict["external_signals"]:
-                measurements["plant_power_reference"] = (
-                    h_dict["external_signals"]["plant_power_reference"]
-                )
+            if "plant_power_reference" in external_signals:
+                measurements["plant_power_reference"] = external_signals["plant_power_reference"]
 
-            if "wind_power_reference" in h_dict["external_signals"] and self._has_wind_component:
-                measurements["wind_farm"]["power_reference"] = (
-                    h_dict["external_signals"]["wind_power_reference"]
-                )
+            if "wind_power_reference" in external_signals and self._has_wind_component:
+                measurements["wind_farm"]["power_reference"] = external_signals[
+                    "wind_power_reference"
+                ]
 
-            if "solar_power_reference" in h_dict["external_signals"] and self._has_solar_component:
-                measurements["solar_farm"]["power_reference"] = (
-                    h_dict["external_signals"]["solar_power_reference"]
-                )
+            if "solar_power_reference" in external_signals and self._has_solar_component:
+                measurements["solar_farm"]["power_reference"] = external_signals[
+                    "solar_power_reference"
+                ]
 
             if self._has_battery_component:
-                if "battery_power_reference" in h_dict["external_signals"]:
-                    measurements["battery"]["power_reference"] = (
-                        h_dict["external_signals"]["battery_power_reference"]
-                    )
+                if "battery_power_reference" in external_signals:
+                    measurements["battery"]["power_reference"] = external_signals[
+                        "battery_power_reference"
+                    ]
 
-            if "hydrogen_reference" in h_dict["external_signals"] and self._has_hydrogen_component:
-                measurements["hydrogen"]["power_reference"] = (
-                    h_dict["external_signals"]["hydrogen_reference"]
-                )
+            if "hydrogen_reference" in external_signals and self._has_hydrogen_component:
+                measurements["hydrogen"]["power_reference"] = external_signals["hydrogen_reference"]
 
-            # Grid price information
-            if "lmp_da_00" in h_dict["external_signals"]:
-                measurements["DA_LMP_24hours"] = [
-                    h_dict["external_signals"]["lmp_da_{:02d}".format(h)] for h in range(24)
-                ]
-            if "lmp_da" in h_dict["external_signals"]:
-                measurements["DA_LMP"] = h_dict["external_signals"]["lmp_da"]
-            if "lmp_rt" in h_dict["external_signals"]:
-                measurements["RT_LMP"] = h_dict["external_signals"]["lmp_rt"]
+            # Grid price information (using pre-computed keys for performance)
+            if "lmp_da_00" in external_signals:
+                measurements["DA_LMP_24hours"] = [external_signals[k] for k in self._lmp_da_keys]
+            if "lmp_da" in external_signals:
+                measurements["DA_LMP"] = external_signals["lmp_da"]
+            if "lmp_rt" in external_signals:
+                measurements["RT_LMP"] = external_signals["lmp_rt"]
 
             # Special handling for forecast elements
-            for k in h_dict["external_signals"].keys():
+            for k, v in external_signals.items():
                 if "forecast" in k:
-                    measurements["forecast"][k] = h_dict["external_signals"][k]
+                    measurements["forecast"][k] = v
 
         measurements["total_power"] = total_power
 


### PR DESCRIPTION
Some of the lines in `get_measurements` unnecessarily slow the function down.  This small PR gains speed up by:
1) Saving the names of lmp_da_keys rather then running string formatting and list comprehension each step
2) Caching `h_dict["external_signals"]` into `external_signals`

Profiling suggests this is worth a 2.5x speedup, going to run a full case to confirm
