### PR TITLE
set high soc default to 1

### DIFF
--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -232,8 +232,8 @@ class BatteryPriceSOCController(ControllerBase):
         very high prices is worthwhile.
 
         Args:
-            high_soc (float): High SOC threshold (0 to 1).
-            low_soc (float): Low SOC threshold (0 to 1).
+            high_soc (float): High SOC threshold (0 to 1).  Defaults to 1.0.
+            low_soc (float): Low SOC threshold (0 to 1).  Defaults to 0.2.
         """
         self.high_soc = high_soc
         self.low_soc = low_soc

--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -213,18 +213,23 @@ class BatteryPriceSOCController(ControllerBase):
 
     def set_controller_parameters(
         self,
-        high_soc=0.8,
+        high_soc=1.0,
         low_soc=0.2,
         **_,  # <- Allows arbitrary additional parameters to be passed, which are ignored
     ):
         """
         Set parameters for BatteryPriceSOCController.
 
-        high_soc is the SOC threshold above which the battery will only charge if the price is above
-        the highest (hourly) DA price of the day.
+        high_soc is the SOC threshold above which the battery will only charge if the price is below
+        the lowest (hourly) DA price of the day.  Defaults to 1.0.
 
         low_soc is the SOC threshold below which the battery will only discharge if the price is
-        below the lowest (hourly) DA price of the day.
+        above the highest (hourly) DA price of the day.  Defaults to 0.2.
+
+        Note high_soc defaults to 1.0 (effictively disabled) since experience suggests waiting for 
+        very low prices is not worthwhile.  On the other hand, 
+        low_soc defaults to 0.2 since experience suggests waiting for 
+        very high prices is worthwhile.
 
         Args:
             high_soc (float): High SOC threshold (0 to 1).

--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -226,7 +226,7 @@ class BatteryPriceSOCController(ControllerBase):
         low_soc is the SOC threshold below which the battery will only discharge if the price is
         above the highest (hourly) DA price of the day.  Defaults to 0.2.
 
-        Note high_soc defaults to 1.0 (effictively disabled) since experience suggests waiting for
+        Note high_soc defaults to 1.0 (effectively disabled) since experience suggests waiting for
         very low prices is not worthwhile.  On the other hand,
         low_soc defaults to 0.2 since experience suggests waiting for
         very high prices is worthwhile.

--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -226,10 +226,9 @@ class BatteryPriceSOCController(ControllerBase):
         low_soc is the SOC threshold below which the battery will only discharge if the price is
         above the highest (hourly) DA price of the day.  Defaults to 0.2.
 
-        Note high_soc defaults to 1.0 (effectively disabled) since experience suggests waiting for
-        very low prices is not worthwhile.  On the other hand,
-        low_soc defaults to 0.2 since experience suggests waiting for
-        very high prices is worthwhile.
+        high_soc defaults to 1.0 (effectively disabled) as experience suggests waiting for
+        very low prices is not worthwhile. low_soc defaults to 0.2 as experience suggests waiting
+        for very high prices is worthwhile.
 
         Args:
             high_soc (float): High SOC threshold (0 to 1).  Defaults to 1.0.

--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -226,9 +226,9 @@ class BatteryPriceSOCController(ControllerBase):
         low_soc is the SOC threshold below which the battery will only discharge if the price is
         above the highest (hourly) DA price of the day.  Defaults to 0.2.
 
-        Note high_soc defaults to 1.0 (effictively disabled) since experience suggests waiting for 
-        very low prices is not worthwhile.  On the other hand, 
-        low_soc defaults to 0.2 since experience suggests waiting for 
+        Note high_soc defaults to 1.0 (effictively disabled) since experience suggests waiting for
+        very low prices is not worthwhile.  On the other hand,
+        low_soc defaults to 0.2 since experience suggests waiting for
         very high prices is worthwhile.
 
         Args:


### PR DESCRIPTION
The controller `BatteryPriceSOCController` uses `high_soc` and `low_soc` to determine if charging/discharging should happen or if should wait for higher/lower prices.  Experience with demonstrations shows while the `low_soc` being used (set for example to 0.2) adds value, effectively disabling `high_soc` by setting to 1.0 is the better setting.  This makes some sense in that RT LMPs can feature very high price spikes, but on the low end their is often a pretty clear floor in-between 0 and $-26.  Waiting to charge for very low prices does not seem to pay off given this asymmetric skew in prices.

This PR sets the default values accordingly and updates the docstring.  