### PR TITLE
Update URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ and creates an entry point for the development of more advanced controllers.
 
 Hycon will interface with various simulation testbeds and lower level 
 controllers, including:
-- [Hercules](https://github.com/NREL/hercules)
+- [Hercules](https://github.com/NatLabRockies/hercules)
 - [FAST.Farm](https://github.com/OpenFAST/openfast)
-- [ROSCO](https://github.com/NREL/rosco)
+- [ROSCO](https://github.com/NatLabRockies/rosco)
 
 Hycon controllers will also call on design tools such as
-[FLORIS](https://github.com/NREL/floris).
+[FLORIS](https://github.com/NatLabRockies/floris).
 
 ## WETO software
 
 Hycon is primarily developed with the support from the U.S. Department of Energy and
-is part of the [WETO Software Stack](https://nrel.github.io/WETOStack).
+is part of the [WETO Software Stack](https://natlabrockies.github.io/WETOStack).
 For more information and other integrated modeling software, see:
 
-- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
-- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
+- [Portfolio Overview](https://natlabrockies.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://natlabrockies.github.io/WETOStack/_static/entry_guide/index.html)
 - [Wind Farm Controls Workshop](https://www.youtube.com/watch?v=f-w6whxIBrA&list=PL6ksUtsZI1dwRXeWFCmJT6cEN1xijsHJz)
 
 NLR's software record for Hycon is SWR-25-54.
@@ -33,4 +33,4 @@ NLR's software record for Hycon is SWR-25-54.
 ## Documentation
 
 Documentation for Hycon, including installation instructions, can be found
-[here](https://nrel.github.io/hycon/intro.html).
+[here](https://natlabrockies.github.io/hycon/intro.html).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/NREL/hycon
+  url: https://github.com/NatLabRockies/hycon
   path_to_book: docs
   branch: main
 

--- a/docs/code_development.md
+++ b/docs/code_development.md
@@ -1,6 +1,6 @@
 # Code development
 To contribute to Hycon, please consider forking the main github repository,
-with the [NLR repo](https://github.com/NREL/hycon) as an 
+with the [NLR repo](https://github.com/NatLabRockies/hycon) as an 
 upstream remote. See the [Installation instructions](install_instructions) 
 for details about how to set up your repository as a developer.
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -43,7 +43,7 @@ However, is a useful comparison case for the WindFarmPowerTrackingController
 Closed-loop wind farm-level power controller that distributes a farm-level 
 power reference among the wind turbines in a farm and adjusts the requests made
 from each turbine depending on whether the power reference has been met. 
-Developed under the [A2e2g project](https://github.com/NREL/a2e2g), with 
+Developed under the [A2e2g project](https://github.com/NatLabRockies/a2e2g), with 
 further details provided in 
 [Sinner et al.](https://pubs.aip.org/aip/jrse/article/15/5/053304/2913100).
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -43,8 +43,7 @@ However, is a useful comparison case for the WindFarmPowerTrackingController
 Closed-loop wind farm-level power controller that distributes a farm-level 
 power reference among the wind turbines in a farm and adjusts the requests made
 from each turbine depending on whether the power reference has been met. 
-Developed under the [A2e2g project](https://github.com/NatLabRockies/a2e2g), with 
-further details provided in 
+Further details provided in 
 [Sinner et al.](https://pubs.aip.org/aip/jrse/article/15/5/053304/2913100).
 
 Integral action, as well as gain scheduling based on turbine saturation, has been disabled as 

--- a/docs/install_instructions.md
+++ b/docs/install_instructions.md
@@ -3,9 +3,9 @@
 
 Hycon is _not_ designed to be used as a stand-alone package. Most likely, 
 you'll want to add Hycon to an existing conda environment that contains your
-simulation testbed, such as [Hercules](https://github.com/NREL/hercules). 
+simulation testbed, such as [Hercules](https://github.com/NatLabRockies/hercules). 
 For example, see the 
-[Hercules installation instructions](https://nrel.github.io/hercules/install_instructions.html)
+[Hercules installation instructions](https://natlabrockies.github.io/hercules/install_instructions.html)
 for how to set up an appropriate conda environment.
 
 (installation_general_users)=
@@ -16,7 +16,7 @@ be sufficient to install Hycon (presumably, after activating your conda
 environment):
 
 ```
-git clone https://github.com/NREL/hycon
+git clone https://github.com/NatLabRockies/hycon
 pip install hycon/
 ```
 
@@ -32,7 +32,7 @@ git clone https://github.com/your-github-id/hycon
 pip install -e "hycon/[develop]"
 ```
 To contribute back to the base repository 
-https://github.com/NREL/hycon, please do the following:
+https://github.com/NatLabRockies/hycon, please do the following:
 - Create a branch from the base repository's `develop` branch on your fork 
 containing your code changes (e.g. `your-github-id:feature/your-new-feature`)
 - Open a pull request into the base repository's `NREL:develop` branch, and provide 
@@ -49,7 +49,7 @@ For more information on what your pull request should contain, see
 (installation_examples)=
 ## To run examples
 
-All Hycon examples run in the [Hercules](https://github.com/NREL/hercules) simulation environment.
+All Hycon examples run in the [Hercules](https://github.com/NatLabRockies/hercules) simulation environment.
 To run the examples, you will need to additionally install Hercules. See the 
-[Hercules installation instructions](https://nrel.github.io/hercules/install_instructions.html)
+[Hercules installation instructions](https://natlabrockies.github.io/hercules/install_instructions.html)
 for details.

--- a/docs/wake_steering_design.md
+++ b/docs/wake_steering_design.md
@@ -3,11 +3,11 @@
 The `hycon.design_tools.wake_steering_design` module provides various tools for the design of yaw
 offset lookup tables for "open-loop" wake steering. The two primary functions are `build_simple_wake_steering_lookup_table` and `build_uncertain_wake_steering_lookup_table`, both of
 which take an instantiated
-[`FlorisModel`](https://nrel.github.io/floris/_autosummary/floris.floris_model.html),
+[`FlorisModel`](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html),
 along with various design parameters, and return a pandas DataFrame `df_opt` containing the optimal
 yaw offset angles for each wind turbine. Under the hood, both functions run an optimization using
 FLORIS'
-[`YawOptimizerSR`](https://nrel.github.io/floris/_autosummary/floris.optimization.yaw_optimization.yaw_optimizer_sr.html) methodology. The `uncertain` version takes into account wind direction
+[`YawOptimizerSR`](https://natlabrockies.github.io/floris/_autosummary/floris.optimization.yaw_optimization.yaw_optimizer_sr.html) methodology. The `uncertain` version takes into account wind direction
 uncertainty via the second required argument `wd_std`, representing the wind direction standard
 deviation.
 

--- a/examples/readme.txt
+++ b/examples/readme.txt
@@ -1,2 +1,2 @@
-See https://nrel.github.io/hycon/examples.html for documentation describing
+See https://natlabrockies.github.io/hycon/examples.html for documentation describing
 the Hycon examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ develop = [
 include = ["hycon*"]
 
 [project.urls]
-Homepage = "https://github.com/NREL/hycon"
-Documentation = "https://nrel.github.io/hycon/intro.html"
+Homepage = "https://github.com/NatLabRockies/hycon"
+Documentation = "https://natlabrockies.github.io/hycon/intro.html"
 
 [coverage.run]
 # Coverage.py configuration file


### PR DESCRIPTION
The github.com/NREL organization is moving to github.com/NatLabRockies. This PR, which should _not_ be merged until the organization changes over, updates various URLs in the documentation to adhere to this change. In particular:
- github.com/NREL/hycon -> github.com/NatLabRockies/hycon
- nrel.github.io/hycon -> natlabrockies.github.io/hycon

Various external links are also updated. These should be checked for correctness prior to merger of this PR.
- [x] https://github.com/nrel/rosco
- [x] https://nrel.github.io/WETOStack/
- [x] https://github.com/nrel/hercules