### PR TITLE
Port over hyconx controllers

### DIFF
--- a/hycon/controllers/battery_controller.py
+++ b/hycon/controllers/battery_controller.py
@@ -266,3 +266,136 @@ class BatteryPriceSOCController(ControllerBase):
             power_setpoint = 0.0
 
         return {"power_setpoint": power_setpoint}
+
+
+
+class BatteryPriceSOCController_ChargeFromPlant(ControllerBase):
+    """
+    Controller considers price and SOC to determine power setpoint.
+
+    This controller edits the hycon controller `BatteryPriceSOCController` to work
+    with HybridSupervisoryController_DGL_PriceSOCBattery
+
+    Differences from BatteryPriceSOCController:
+    1) Max and min SOC of the battery used to clip output to avoid over-starting opportunity
+      to charge discharge to hybrid controller.  (This is a necessary fix because the hybrid
+      controller uses this "desire to charge" to infer how much it can export before
+      hitting the DGL.)
+    2) Since we assume we can't charge from grid, and we assume that the plant won't export
+      in negative prices, we set all negative prices to 0 in day_ahead_lmps to avoid any
+      false prioritization.
+    """
+
+    def __init__(self, interface, input_dict, controller_parameters={}, verbose=True):
+        super().__init__(interface, verbose)
+
+        # Check that parameters are not specified both in input file
+        # and in controller_parameters
+        if "controller" in input_dict:
+            for cp in controller_parameters.keys():
+                if cp in input_dict["controller"]:
+                    raise KeyError(
+                        'Found key "' + cp + '" in both input_dict["controller"] and'
+                        " in controller_parameters."
+                    )
+            controller_parameters = {**controller_parameters, **input_dict["controller"]}
+        self.set_controller_parameters(**controller_parameters)
+
+        self.rated_power_charging = input_dict["battery"]["charge_rate"]
+        self.rated_power_discharging = input_dict["battery"]["discharge_rate"]
+
+        # Save the duration rounded to nearest hour
+        self.duration = round(
+            interface.plant_parameters["battery"]["energy_capacity"]
+            / interface.plant_parameters["battery"]["power_capacity"]
+        )
+
+        # Raise if duration makes this controller implausible
+        if self.duration >= 12:
+            raise ValueError(
+                f"Battery duration is {self.duration} hours, which is not "
+                "supported by BatteryPriceSOCController."
+                " This controller is only intended for durations shorter than 12 hours."
+            )
+
+        if self.duration < 1:
+            raise ValueError(
+                f"Battery duration is {self.duration} hours, which is not "
+                "supported by BatteryPriceSOCController."
+                " This controller is only intended for durations of at least 1 hour."
+            )
+
+        # Save the max and min SOC of the battery
+        self.max_SOC = input_dict["battery"]["max_SOC"]
+        self.min_SOC = input_dict["battery"]["min_SOC"]
+
+    def set_controller_parameters(
+        self,
+        high_soc=1.0,
+        low_soc=0.2,
+        **_,  # <- Allows arbitrary additional parameters to be passed, which are ignored
+    ):
+        """
+        Set parameters for BatteryPriceSOCController.
+
+        high_soc is the SOC threshold above which the battery will only charge if the price is below
+        the lowest (hourly) DA price of the day.  Defaults to 1.0.
+
+        low_soc is the SOC threshold below which the battery will only discharge if the price is
+        above the highest (hourly) DA price of the day.  Defaults to 0.2.
+
+        Note high_soc defaults to 1.0 (effictively disabled) since experience suggests waiting for 
+        very low prices is not worthwhile.  On the other hand, 
+        low_soc defaults to 0.2 since experience suggests waiting for 
+        very high prices is worthwhile.
+
+        Args:
+            high_soc (float): High SOC threshold (0 to 1).  Defaults to 1.0.
+            low_soc (float): Low SOC threshold (0 to 1).  Defaults to 0.2.
+        """
+        self.high_soc = high_soc
+        self.low_soc = low_soc
+
+    def compute_controls(self, measurements_dict):
+        day_ahead_lmps = np.array(measurements_dict["DA_LMP_24hours"])
+
+        # Set all negative prices to 0
+        day_ahead_lmps[day_ahead_lmps < 0] = 0
+
+        sorted_day_ahead_lmps = np.sort(day_ahead_lmps)
+        real_time_lmp = measurements_dict["RT_LMP"]
+
+        # Extract limits
+        bottom_d = sorted_day_ahead_lmps[self.duration - 1]
+        top_d = sorted_day_ahead_lmps[-self.duration]
+        bottom_1 = sorted_day_ahead_lmps[0]
+        top_1 = sorted_day_ahead_lmps[-1]
+
+        # Access the state of charge and LMP in real-time
+        soc = measurements_dict["battery"]["state_of_charge"]
+
+        # Note that the convention is followed where charging is negative power
+        # This matches what is in place in the hercules/hybrid_plant level and
+        # will be inverted before passing into the battery modules
+        if real_time_lmp > top_1:
+            power_setpoint = self.rated_power_discharging
+        elif (real_time_lmp > top_d) & (soc > self.low_soc):
+            power_setpoint = self.rated_power_discharging
+        elif real_time_lmp < bottom_1:
+            power_setpoint = -self.rated_power_charging
+        elif (real_time_lmp < bottom_d) & (soc < self.high_soc):
+            power_setpoint = -self.rated_power_charging
+        else:
+            power_setpoint = 0.0
+
+        # Limit the power_setpoint by the SOC
+        if power_setpoint > 0:  # Trying to discharge
+            if soc <= self.min_SOC:  # Fully depleted
+                power_setpoint = 0.0
+
+        # Other way
+        if power_setpoint < 0:  # Trying to charge
+            if soc >= self.max_SOC:  # Fully charged
+                power_setpoint = 0.0
+
+        return {"power_setpoint": power_setpoint}

--- a/hycon/controllers/hybrid_supervisory_controller.py
+++ b/hycon/controllers/hybrid_supervisory_controller.py
@@ -352,3 +352,312 @@ class HybridSupervisoryControllerMultiRef(HybridSupervisoryControllerBase):
         return wind_reference, solar_reference, battery_reference
 
     # TODO: Need to add it's own compute_controls method that ensures interconnect is satisfied
+
+
+
+class HybridSupervisoryController_DGL_PriceSOCBattery(HybridSupervisoryControllerBase):
+    """
+    This controller includes DGL as in HybridSupervisoryController_DGL_IntegratedBattery, but
+    it is meant to work with the price-based BatteryPriceSOCController_ChargeFromPlant controller
+    rather then the simpler integrated battery controller.
+    """
+
+    def __init__(
+        self,
+        interface,
+        input_dict,
+        wind_controller=None,
+        solar_controller=None,
+        battery_controller=None,
+        controller_parameters={},
+        verbose=False,
+    ):
+        super().__init__(
+            interface=interface,
+            input_dict=input_dict,
+            wind_controller=wind_controller,
+            solar_controller=solar_controller,
+            battery_controller=battery_controller,
+            verbose=verbose,
+        )
+
+        # Extract interconnection limit
+        if "interconnect_limit" in self.plant_parameters:
+            if (
+                not isinstance(
+                    self.plant_parameters["interconnect_limit"], (float, int)
+                )
+                or self.plant_parameters["interconnect_limit"] <= 0
+            ):
+                raise ValueError("interconnect_limit must be a positive value.")
+        else:
+            self.plant_parameters["interconnect_limit"] = np.inf
+
+        # Initialize the dynamic interconnect limit to the interconnect limit
+        self.dynamic_grid_limit = self.plant_parameters["interconnect_limit"]
+        self.dgl_prev_state = 1  # -1 / 0 / 1 (negative price / 0 / positive price)
+
+        # Get the input controller parameters
+        input_controller_parameters = input_dict["controller"]
+        if input_controller_parameters is None:
+            input_controller_parameters = {}
+
+        # Check that parameters are not specified both in input file
+        # and in controller_parameters
+        for cp in controller_parameters.keys():
+            if cp in input_controller_parameters:
+                raise KeyError(
+                    'Found key "' + cp + '" in both input_dict["controller"] and'
+                    " in controller_parameters."
+                )
+        controller_parameters = {**controller_parameters, **input_controller_parameters}
+        self.set_controller_parameters(**controller_parameters)
+
+        # Set initial values for filtered powers
+        self._wind_ref_filtered = 0.0
+        self._solar_ref_filtered = 0.0
+        self._batt_ref_filtered = 0.0
+
+    def set_controller_parameters(
+        self,
+        filter_time_constant=0.0,
+        curtailment_order=None,
+        allow_grid_charging=False,
+        **_,  # <- Allows arbitrary additional parameters to be passed, which are ignored
+    ):
+        # Establish curtailment protocols
+        default_curtailment_order = ["battery", "solar", "wind"]
+        default_curtailment_order = [
+            c
+            for c, a in zip(
+                default_curtailment_order,
+                [
+                    self._has_battery_controller,
+                    self._has_solar_controller,
+                    self._has_wind_controller,
+                ],
+                strict=False,
+            )
+            if a
+        ]
+        if curtailment_order is not None:
+            # Check that curtailment order does not contain any invalid components
+            for component in curtailment_order:
+                if component not in default_curtailment_order:
+                    raise ValueError(
+                        f"Invalid component {component} in curtailment_order. "
+                        "Valid components based on configuration provided are: "
+                        ", ".join(default_curtailment_order)
+                    )
+            self.curtailment_order = curtailment_order
+        else:
+            self.curtailment_order = default_curtailment_order
+        # TODO: consider adding a price-ordered version of curtailment order.
+
+        self._b = self.dt / (filter_time_constant + self.dt)
+        self._a = filter_time_constant / (filter_time_constant + self.dt)
+
+        self.allow_grid_charging = allow_grid_charging
+
+    def _update_dynamic_grid_limit(self, measurements_dict, total_power):
+        """
+        Update the dynamic interconnection limit (DIL) based on the measurements.
+        """
+        NEAR_ZERO_PRICE = 0.1  # $/MWh
+        RAMP_RATE = 40000  # kW / 5 minutes
+
+        # If this is a 5 minute step
+        # TODO: ASSUMING WE START ON AN EVEN TIME AND DT IS SUCH
+        # THAT 300 IS AN INTEGER NUMBER OF STEPS
+        if measurements_dict["time"] % 300 == 0:
+            if measurements_dict["RT_LMP"] < -1 * NEAR_ZERO_PRICE:
+                # DECREASING CONDITION
+                if self.dgl_prev_state == 1:  # Coming from positive price
+                    self.dynamic_grid_limit = total_power - RAMP_RATE
+                else:  # continuing negative or 0 price
+                    self.dynamic_grid_limit = self.dynamic_grid_limit - RAMP_RATE
+                self.dgl_prev_state = -1
+            elif measurements_dict["RT_LMP"] < NEAR_ZERO_PRICE:
+                # 0 price condition
+                if self.dgl_prev_state == 1:  # Coming from positive price
+                    self.dynamic_grid_limit = total_power - RAMP_RATE
+                # Otherwise no update in 0 price condition
+                self.dgl_prev_state = 0
+            else:
+                self.dynamic_grid_limit = self.dynamic_grid_limit + RAMP_RATE
+                self.dgl_prev_state = 1
+
+            # Limit the DIL to the [0, interconnect limit] range
+            self.dynamic_grid_limit = np.maximum(self.dynamic_grid_limit, 0.0)
+            self.dynamic_grid_limit = np.minimum(
+                self.dynamic_grid_limit, self.plant_parameters["interconnect_limit"]
+            )
+
+    def supervisory_control(self, measurements_dict, battery_power_setpoint):
+        """
+        Overwrite HybridSupervisoryControllerBaseline.supervisory_control()
+        with controller that follows separate setpoints and curtails in order.
+        """
+
+        # # Temporarily hard code these values
+        # BATTERY_CHARGE_PRICE = 0 # $/MWh
+        # BATTERY_DISCHARGE_PRICE = 5 # $/MWh
+        NEAR_ZERO_PRICE = 0.1  # $/MWh
+
+        # Get current power production of the various components
+        wind_power = (
+            np.array(measurements_dict["wind_farm"]["turbine_powers"]).sum()
+            if self._has_wind_controller
+            else 0
+        )
+        solar_power = (
+            measurements_dict["solar_farm"]["power"]
+            if self._has_solar_controller
+            else 0
+        )
+        battery_power = (
+            measurements_dict["battery"]["power"] if self._has_battery_controller else 0
+        )
+
+        total_power = wind_power + solar_power + battery_power
+        total_power_generating_power = wind_power + solar_power  # + battery_power
+
+        # Update the dynamic interconnect limit
+        self._update_dynamic_grid_limit(measurements_dict, total_power)
+
+        # Identify the headroom before account for battery
+        dgl_headroom_pre_battery_charging = (
+            self.dynamic_grid_limit - total_power_generating_power
+        )
+
+        # Compute the dgl_headroom accounting the battery_power_setpoint (instead of actual battery
+        # power use the reference to avoid chicken-and-egg)
+        if not self.allow_grid_charging or battery_power_setpoint >= 0:
+            # If grid charging is not allowed or the battery power setpoint is above zero, then the dgl_headroom is the dgl_headroom_pre_battery_charging
+            # minus the battery_power_setpoint
+            dgl_headroom = dgl_headroom_pre_battery_charging - battery_power_setpoint
+        else:
+            # If grid charging is allowed and the setpoint is negative, then the dgl_headroom is the dgl_headroom_pre_battery_charging
+            # since the battery is better off charging from the grid than from the local power
+            dgl_headroom = dgl_headroom_pre_battery_charging
+
+        # Initialize references
+        wind_reference = 0.0
+        solar_reference = 0.0
+        battery_curtailed_setpoint = 0.0
+
+        for component in self.curtailment_order:
+            if component == "wind":
+                wind_reference = np.maximum(0.0, wind_power + dgl_headroom)
+                dgl_headroom += wind_power
+            elif component == "solar":
+                solar_reference = np.maximum(0.0, solar_power + dgl_headroom)
+                dgl_headroom += solar_power
+            elif component == "battery":
+                # Limit power only if discharging
+                if battery_power_setpoint >= 0:
+                    battery_curtailed_setpoint = np.maximum(
+                        0.0, battery_power_setpoint + dgl_headroom
+                    )
+                    battery_curtailed_setpoint = np.minimum(
+                        battery_curtailed_setpoint, battery_power_setpoint
+                    )
+                    dgl_headroom += battery_power_setpoint
+                else:
+                    battery_curtailed_setpoint = battery_power_setpoint
+
+        # Apply filtering to set points sent back to component controllers
+        self._wind_ref_filtered = (
+            self._a * self._wind_ref_filtered + self._b * wind_reference
+        )
+        self._solar_ref_filtered = (
+            self._a * self._solar_ref_filtered + self._b * solar_reference
+        )
+        # self._batt_ref_filtered = (
+        #     self._a * self._batt_ref_filtered + self._b * battery_curtailed_setpoint
+        # )
+        # self._batt_charge_lim_filtered = (
+        #     self._a * self._batt_charge_lim_filtered + self._b * battery_charge_limit
+        # )
+        # self._batt_discharge_lim_filtered = (
+        #     self._a * self._batt_discharge_lim_filtered
+        #     + self._b * battery_discharge_limit
+        # )
+
+        return (
+            self._wind_ref_filtered,
+            self._solar_ref_filtered,
+            battery_curtailed_setpoint,
+        )
+
+    def compute_controls(self, measurements_dict):
+        # Initialize the controls_dict
+        controls_dict = {}
+
+        # Compute the battery setpoint ahead of the supervisory controller
+        if self._has_battery_controller:
+            # measurements_dict["battery"]["power_reference"] = battery_reference
+            battery_controls_dict = self.battery_controller.compute_controls(
+                measurements_dict
+            )
+
+            controls_dict["battery_power_setpoint"] = battery_controls_dict[
+                "power_setpoint"
+            ]
+        else:
+            # No battery controller, so battery setpoint is 0
+            controls_dict["battery_power_setpoint"] = 0.0
+
+        # Run supervisory control logic
+        wind_reference, solar_reference, battery_curtailed_setpoint = (
+            self.supervisory_control(
+                measurements_dict,
+                battery_power_setpoint=controls_dict["battery_power_setpoint"],
+            )
+        )
+
+        # Package the controls for the individual controllers, step, and return
+        if self._has_wind_controller:
+            measurements_dict["wind_farm"]["power_reference"] = wind_reference
+            wind_controls_dict = self.wind_controller.compute_controls(
+                measurements_dict
+            )
+            controls_dict["wind_power_setpoints"] = wind_controls_dict[
+                "power_setpoints"
+            ]
+        if self._has_solar_controller:
+            measurements_dict["solar_farm"]["power_reference"] = solar_reference
+            solar_controls_dict = self.solar_controller.compute_controls(
+                measurements_dict
+            )
+            controls_dict["solar_power_setpoint"] = solar_controls_dict[
+                "power_setpoint"
+            ]
+        if self._has_battery_controller:
+            # Overwrite curtailed version
+            controls_dict["battery_power_setpoint"] = battery_curtailed_setpoint
+
+            # Finally limit battery charging to available local power if grid charging is not allowed
+            if (
+                controls_dict["battery_power_setpoint"] < 0
+                and not self.allow_grid_charging
+            ):
+                wind_power = (
+                    np.array(measurements_dict["wind_farm"]["turbine_powers"]).sum()
+                    if self._has_wind_controller
+                    else 0
+                )
+                solar_power = (
+                    measurements_dict["solar_farm"]["power"]
+                    if self._has_solar_controller
+                    else 0
+                )
+
+                controls_dict["battery_power_setpoint"] = np.max(
+                    [
+                        controls_dict["battery_power_setpoint"],
+                        -1 * (wind_power + solar_power),
+                    ]
+                )
+
+        return controls_dict


### PR DESCRIPTION
Port over controllers from private development for use on Hycon.  These controllers are:

`HybridSupervisoryController_DGL_PriceSOCBattery` This is a supervisory controller using DGL = Dynamic Grid Limit, which allows for curtailment based on RT prices with an assumed ramping limit.  Also helps to reconcile battery charging/discharging impact on POI limit.

`BatteryPriceSOCController_ChargeFromPlant` a battery controller where charging is limited to local power and can't grid charge.

This PR opening in draft is just a first step.  See the following next steps as:

- [ ] Do class names make sense/fit pattern
- [ ] These were created a few versions of Hycon ago, are they still up to date?
- [ ] Docstrings need to be cleaned up
- [ ] tests?
- [ ] examples?
- [ ] docs?
- [ ] linting and formatting

